### PR TITLE
rakudist scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Makefile
 /resources/
 .precomp/
+.tom

--- a/.rakudist/depends.raku
+++ b/.rakudist/depends.raku
@@ -1,0 +1,4 @@
+git://github.com/frithnanth/raku-Math-Libgsl-Constants.git
+git://github.com/frithnanth/raku-Math-Libgsl-Complex.git
+git://github.com/frithnanth/raku-Math-Libgsl-Matrix.git
+

--- a/.rakudist/sparrowfile
+++ b/.rakudist/sparrowfile
@@ -1,0 +1,4 @@
+package-install %(
+  alpine => qqw{gsl gsl-dev make gcc g++},
+  debian => qqw{libgsl23 libgsl-dev libgslcblas0}
+);


### PR DESCRIPTION
This is a small patch to allow distribution test on [RakuDist](https://github.com/melezhik/RakuDist).

Test could be run through an API:

`curl -d os=alpine -d project=melezhik/raku-Math-Libgsl-Permutation http://repo.westus.cloudapp.azure.com/rakudist/api/run/:github`

You can run tests against different os (so far is debian and alpine). I eventually will add more OS.

Once it's merged you can run tests against your GH source code or CPAN distribution.

